### PR TITLE
fix: update the demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ All property is copyright Bethesda and id software.
 [http://wolfenstein.bethsoft.com/](http://wolfenstein.bethsoft.com)
 
 You can play this in your browser using:
-https://loadx.github.com/html5-wolfenstein3D
+https://loadx.github.io/html5-wolfenstein3D
 
 _p.s If anyone at Bethesda or id software has objections to this being hosted on github please let me know and I will remove it but I assume because Wolfenstein 3D is open source then you won't mind :)_


### PR DESCRIPTION
I have noticed a dead link in [`README.md`](https://github.com/loadx/html5-wolfenstein3D/blob/420f309991eb5e1bdc30d09df7557185ffd4ef50/README.md). This pull request fixes it.
