### PR TITLE
Update mugshot frame formula to be closer to vanilla Wolf3d.

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -481,7 +481,8 @@ Wolf.Game = (function() {
             player.faceGotGun = player.faceOuch = false;
             player.faceFrame = Wolf.Random.rnd() >> 6;
             if( player.faceFrame == 3) {
-                player.faceFrame = 0;
+                // DenisBelmondo@github: mugshot-fix
+                player.faceFrame = 1;
             }
             player.faceCount = 0;
         }
@@ -497,7 +498,9 @@ Wolf.Game = (function() {
                 if (h < 0) {
                     h = 0;
                 }
-                pic = (3*((100-h)/16)>>0) + player.faceFrame;
+                
+                // DenisBelmondo@github: mugshot-fix
+                pic = (3*(((100-h)/16)|0)|0) + player.faceFrame;
                 
                 //gsh
                 if ((player.flags & Wolf.FL_GODMODE)) {


### PR DESCRIPTION
Previously, the mugshot frame was offset by one in some cases like 28% health or some non-multiple of 10. This PR fixes that behavior as well as bringing it closer to the original Wolfenstein 3D behavior. [Reference.](https://github.com/id-Software/wolf3d/blob/05167784ef009d0d0daefe8d012b027f39dc8541/WOLFSRC/WL_AGENT.C#L270)